### PR TITLE
Update net route_table Terraform templates with new required fields

### DIFF
--- a/net/aws_route_table__private1.tf
+++ b/net/aws_route_table__private1.tf
@@ -4,17 +4,19 @@ resource "aws_route_table" "rtb-0fe5311ff86579482" {
   propagating_vgws = []
   route = [
     {
-      cidr_block                = "0.0.0.0/0"
-      egress_only_gateway_id    = ""
-      gateway_id                = ""
-      instance_id               = ""
-      ipv6_cidr_block           = ""
-      local_gateway_id          = ""
-      nat_gateway_id            = aws_nat_gateway.nat-07b271e3a84d0d94a.id
-      network_interface_id      = ""
-      transit_gateway_id        = ""
-      vpc_peering_connection_id = ""
-      vpc_endpoint_id = ""
+      carrier_gateway_id         = ""
+      cidr_block                 = "0.0.0.0/0"
+      destination_prefix_list_id = ""
+      egress_only_gateway_id     = ""
+      gateway_id                 = ""
+      instance_id                = ""
+      ipv6_cidr_block            = ""
+      local_gateway_id           = ""
+      nat_gateway_id             = aws_nat_gateway.nat-07b271e3a84d0d94a.id
+      network_interface_id       = ""
+      transit_gateway_id         = ""
+      vpc_peering_connection_id  = ""
+      vpc_endpoint_id            = ""
     },
   ]
   tags = {

--- a/net/aws_route_table__public1.tf
+++ b/net/aws_route_table__public1.tf
@@ -4,17 +4,19 @@ resource "aws_route_table" "rtb-0c9df3106b9e1bca9" {
   propagating_vgws = []
   route = [
     {
-      cidr_block                = "0.0.0.0/0"
-      egress_only_gateway_id    = ""
-      gateway_id                = aws_internet_gateway.igw-02c295b01d50c9d3e.id
-      instance_id               = ""
-      ipv6_cidr_block           = ""
-      local_gateway_id          = ""
-      nat_gateway_id            = ""
-      network_interface_id      = ""
-      transit_gateway_id        = ""
-      vpc_peering_connection_id = ""
-      vpc_endpoint_id = ""
+      carrier_gateway_id         = ""
+      cidr_block                 = "0.0.0.0/0"
+      destination_prefix_list_id = ""
+      egress_only_gateway_id     = ""
+      gateway_id                 = aws_internet_gateway.igw-02c295b01d50c9d3e.id
+      instance_id                = ""
+      ipv6_cidr_block            = ""
+      local_gateway_id           = ""
+      nat_gateway_id             = ""
+      network_interface_id       = ""
+      transit_gateway_id         = ""
+      vpc_peering_connection_id  = ""
+      vpc_endpoint_id            = ""
     },
   ]
   tags   = {}


### PR DESCRIPTION
*Description of changes:*

In prepping for an internal AWS workshop, within the last week, the lack of the two fields of `carrier_gateway_id` and `destination_prefix_list_id` in the public and private route tables caused edits to be necessary to these files before performing `terraform apply tfplan`. 

This update adds those fields to the Terraform template which prevents our customers or workshop attendees to have to make this change during the workshop before continuing.

Feel free to contact me internally if you have questions. 😄 