### PR TITLE
Update data-sg-c9-instance.tf

### DIFF
--- a/c9net/data-sg-c9-instance.tf
+++ b/c9net/data-sg-c9-instance.tf
@@ -16,7 +16,7 @@ data "aws_instance" "c9inst" {
     values = ["*${var.c9label}*"]
   }
 }
-
+# line 21 is broken. had to hard code the sg id manully to get it working.
 data "aws_security_group" "c9sg" {
   name = sort(data.aws_instance.c9inst.security_groups)[0]
 }


### PR DESCRIPTION
# line 21 is broken. had to hard code the sg id manully to get it working.
data "aws_security_group" "c9sg" {
  name = sort(data.aws_instance.c9inst.security_groups)[0]
}

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
